### PR TITLE
Description:

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package websocket
+
+import "errors"
+
+var (
+	ErrNilConn    = errors.New("nil *Conn")
+	ErrNilNetConn = errors.New("nil net.Conn")
+)


### PR DESCRIPTION
1. The exported receivers on the websocket.(*Conn) will not panic
2. The websocket.(*Conn) becomes nil, in some instances, leading to unpredictable panics in the receivers i.e websocket.(*Conn).SetWriteDeadline(), websocket.(*Conn).beginMessage()
3. The websocket.(*Conn).(net.Conn) becomes nil, in some instances, leading to unpredicatble panics in i.e websocket.(*Conn).(net.Conn).SetWriteDeadline()
4. The panics are handled by nil pointer check in case of websocket.(*Conn) & nil interface check in case of websocket.(*Conn).(net.Conn) before accessing the fields.
5. The panics are handled in the exported receivers at the moment and based on the need, we can handle the panics similarly in the unexported receivers as well.
6. 2 new errors (websocket.ErrNilConn & websocket.ErrNilNetConn) are defined in errors.go and returned for all the modified receivers, in which an error could be returned.
7. Additional return of an error in all the exported receivers would break existing applications.
8. Prevent the applciation crash from this package, return errors and let the application disconnect the websocket connection gracefully.