### PR TITLE
docs: fix comment typos

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -47,7 +47,7 @@ func (a fakeAddr) String() string {
 	return "str"
 }
 
-// newTestConn creates a connnection backed by a fake network connection using
+// newTestConn creates a connection backed by a fake network connection using
 // default values for buffering.
 func newTestConn(r io.Reader, w io.Writer, isServer bool) *Conn {
 	return newConn(fakeNetConn{Reader: r, Writer: w}, isServer, 1024, 1024, nil, nil, nil)
@@ -149,7 +149,7 @@ func TestFraming(t *testing.T) {
 }
 
 func TestControl(t *testing.T) {
-	const message = "this is a ping/pong messsage"
+	const message = "this is a ping/pong message"
 	for _, isServer := range []bool{true, false} {
 		for _, isWriteControl := range []bool{true, false} {
 			name := fmt.Sprintf("s:%v, wc:%v", isServer, isWriteControl)
@@ -440,7 +440,7 @@ func TestWriteAfterMessageWriterClose(t *testing.T) {
 	w, _ := wc.NextWriter(BinaryMessage)
 	io.WriteString(w, "hello")
 	if err := w.Close(); err != nil {
-		t.Fatalf("unxpected error closing message writer, %v", err)
+		t.Fatalf("unexpected error closing message writer, %v", err)
 	}
 
 	if _, err := io.WriteString(w, "world"); err == nil {

--- a/proxy.go
+++ b/proxy.go
@@ -59,7 +59,7 @@ func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) 
 		return nil, err
 	}
 
-	// Read response. It's OK to use and discard buffered reader here becaue
+	// Read response. It's OK to use and discard buffered reader here because
 	// the remote server does not speak until spoken to.
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, connectReq)


### PR DESCRIPTION
This PR fixes typos in comments test error messages.